### PR TITLE
releasetools: Replace key values in permission files during re-signing

### DIFF
--- a/tools/releasetools/sign_target_files_apks.py
+++ b/tools/releasetools/sign_target_files_apks.py
@@ -221,6 +221,10 @@ def ProcessTargetFiles(input_tf_zip, output_tf_zip, misc_info,
       print("rewriting %s with new keys." % info.filename)
       new_data = ReplaceCerts(data)
       common.ZipWriteStr(output_tf_zip, out_info, new_data)
+    elif info.filename.startswith("SYSTEM/etc/permissions/"):
+      print("rewriting %s with new keys." % info.filename)
+      new_data = ReplaceCerts(data)
+      common.ZipWriteStr(output_tf_zip, out_info, new_data)
     elif info.filename in ("SYSTEM/recovery-from-boot.p",
                            "SYSTEM/bin/install-recovery.sh"):
       rebuild_recovery = True


### PR DESCRIPTION
Permission files may grant permissions based on signatures in the same
way mac_permissions grants selinux permissions. In order to have this
work properly with dev-key and production key signed builds, allow these
files to be re-written during the signing process to replace the value
of the keys in production signed builds.

Change-Id: Id0311e49f8bba5a9f71b2fa49b480cb74779c853
Ticket: CYNGNOS-1877, RM-179